### PR TITLE
Extract common Processor interface

### DIFF
--- a/src/main/java/danta/api/ContentModel.java
+++ b/src/main/java/danta/api/ContentModel.java
@@ -28,17 +28,17 @@ package danta.api;
  */
 public interface ContentModel {
 
-    public ContentModel set(String name, Object value);
+    ContentModel set(String name, Object value);
 
-    public String getAsString(String name);
+    String getAsString(String name);
 
-    public Object get(String name);
+    Object get(String name);
 
-    public <T> T getAs(String name, Class<T> type)
+    <T> T getAs(String name, Class<T> type)
             throws Exception;
 
-    public boolean has(String name);
+    boolean has(String name);
 
-    public <T> boolean is(String name, Class<T> type);
+    <T> boolean is(String name, Class<T> type);
 
 }

--- a/src/main/java/danta/api/ContextProcessor.java
+++ b/src/main/java/danta/api/ContextProcessor.java
@@ -19,7 +19,6 @@
 
 package danta.api;
 
-import danta.Constants;
 import danta.api.exceptions.AcceptsException;
 import danta.api.exceptions.ProcessException;
 
@@ -30,7 +29,8 @@ import danta.api.exceptions.ProcessException;
  * @version     1.0.0
  * @since       2013-10-30
  */
-public interface ContextProcessor<C extends ContentModel> {
+public interface ContextProcessor<C extends ContentModel>
+        extends Processor {
 
     /**
      * Determines if this Processor should handle this Request and add to the Context.
@@ -43,25 +43,6 @@ public interface ContextProcessor<C extends ContentModel> {
      */
     public boolean accepts(final ExecutionContext executionContext)
             throws AcceptsException;
-
-    /**
-     * Returns the priority of this ContextProcessor.
-     * The processors are executed by the TemplatingSupportFilter in descending
-     * order based on the property.
-     * <p>
-     * The priority can be any int number. The following constants are provided
-     * only for convenience:
-     * <ul>
-     *     <li>HIGHEST_PRIORITY   = 1000
-     *     <li>MEDIUM_PRIORITY = 500
-     *     <li>LOW_PRIORITY    = 0
-     * </ul>
-     *
-     * @return the priority of this ContextProcessor
-     * @see Constants
-     *
-     */
-    public int priority();
 
     /**
      * This method is where any business logic resides, and the various results are added to the Context.

--- a/src/main/java/danta/api/ContextProcessor.java
+++ b/src/main/java/danta/api/ContextProcessor.java
@@ -41,7 +41,7 @@ public interface ContextProcessor<C extends ContentModel>
      *
      * @throws AcceptsException
      */
-    public boolean accepts(final ExecutionContext executionContext)
+    boolean accepts(final ExecutionContext executionContext)
             throws AcceptsException;
 
     /**
@@ -52,7 +52,7 @@ public interface ContextProcessor<C extends ContentModel>
      *
      * @throws Exception
      */
-    public void process(final ExecutionContext executionContext, final C contentModel)
+    void process(final ExecutionContext executionContext, final C contentModel)
             throws ProcessException;
 
 }

--- a/src/main/java/danta/api/ContextProcessorEngine.java
+++ b/src/main/java/danta/api/ContextProcessorEngine.java
@@ -41,6 +41,6 @@ public interface ContextProcessorEngine {
      * @throws AcceptsException
      * @throws ProcessException
      */
-    public List<String> execute(ExecutionContext executionContext, ContentModel contentModel)
+    List<String> execute(ExecutionContext executionContext, ContentModel contentModel)
             throws AcceptsException, ProcessException;
 }

--- a/src/main/java/danta/api/DOMProcessor.java
+++ b/src/main/java/danta/api/DOMProcessor.java
@@ -43,6 +43,6 @@ public interface DOMProcessor
      * @param document    The HTML document
      * @throws Exception
      */
-    public void process(final ExecutionContext executionContext, final Document document)
+    void process(final ExecutionContext executionContext, final Document document)
             throws Exception;
 }

--- a/src/main/java/danta/api/DOMProcessor.java
+++ b/src/main/java/danta/api/DOMProcessor.java
@@ -33,15 +33,8 @@ import org.jsoup.nodes.Document;
  * @version     1.0.0
  * @since       2016-07-14
  */
-public interface DOMProcessor {
-
-    /**
-     * This method returns the priority of the DOMProcessor. The priority defines the order in which the
-     * DOMProcessors will be executed.
-     *
-     * @return  Returns the priority of the DOMProcessor
-     */
-    public int priority();
+public interface DOMProcessor
+        extends Processor {
 
     /**
      * This method takes care of the HTML processing, using the JSoup library.

--- a/src/main/java/danta/api/DOMProcessorEngine.java
+++ b/src/main/java/danta/api/DOMProcessorEngine.java
@@ -37,7 +37,7 @@ public interface DOMProcessorEngine {
      * @param document
      * @return An ordered List of the DomProcessors that were executed
      */
-    public List<String> execute(ExecutionContext executionContext, final Document document)
+    List<String> execute(ExecutionContext executionContext, final Document document)
             throws Exception;
 }
 

--- a/src/main/java/danta/api/ExecutionContext.java
+++ b/src/main/java/danta/api/ExecutionContext.java
@@ -28,5 +28,5 @@ package danta.api;
  */
 public interface ExecutionContext {
 
-    public Object get(final String key);
+    Object get(final String key);
 }

--- a/src/main/java/danta/api/Processor.java
+++ b/src/main/java/danta/api/Processor.java
@@ -1,0 +1,54 @@
+/**
+ * Danta API Bundle
+ * (danta.api)
+ *
+ * Copyright (C) 2017 Tikal Technologies, Inc. All rights reserved.
+ *
+ * Licensed under GNU Affero General Public License, Version v3.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.gnu.org/licenses/agpl-3.0.txt
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied;
+ * without even the implied warranty of MERCHANTABILITY.
+ * See the License for more details.
+ */
+
+package danta.api;
+
+import danta.Constants;
+
+/**
+ * Processor
+ *
+ * @author      dhughes
+ * @version     1.0.0
+ * @since       2017-09-08
+ */
+public interface Processor {
+
+    /**
+     * Returns the priority of this Processor.
+     * The processors are executed in descending
+     * order based on the property.
+     * <p>
+     * The priority can be any {@code int} number. The following constants are provided
+     * only for convenience:
+     * <ul>
+     *     <li>HIGHEST_PRIORITY   = 1000
+     *     <li>HIGHER_PRIORITY   = 900
+     *     <li>HIGH_PRIORITY   = 800
+     *     <li>MEDIUM_PRIORITY = 500
+     *     <li>LOW_PRIORITY    = 0
+     * </ul>
+     *
+     * @return the priority of this Processor
+     * @see Constants
+     *
+     */
+    int priority();
+
+}

--- a/src/main/java/danta/api/TemplateContentModel.java
+++ b/src/main/java/danta/api/TemplateContentModel.java
@@ -31,10 +31,10 @@ import net.minidev.json.JSONObject;
 public interface TemplateContentModel
         extends ContentModel {
 
-    public TemplateContentModel setAttribute(final String name, final Object value);
+    TemplateContentModel setAttribute(final String name, final Object value);
 
-    public Object getAttribute(final String name);
+    Object getAttribute(final String name);
 
-    public JSONObject toJSONObject(String... keys);
+    JSONObject toJSONObject(String... keys);
 
 }

--- a/src/main/java/danta/api/configuration/Configuration.java
+++ b/src/main/java/danta/api/configuration/Configuration.java
@@ -37,59 +37,59 @@ import java.util.Set;
  */
 public interface Configuration {
 
-    public Mode defaultMode();
+    Mode defaultMode();
 
-    public Set<String> names(Mode mode)
+    Set<String> names(Mode mode)
             throws Exception;
 
-    public Set<String> names()
+    Set<String> names()
             throws Exception;
 
-    public String asString(String paramName, Mode mode)
+    String asString(String paramName, Mode mode)
             throws Exception;
 
-    public Collection<String> asStrings(String paramName, Mode mode)
+    Collection<String> asStrings(String paramName, Mode mode)
             throws Exception;
 
-    public String asString(String paramName)
+    String asString(String paramName)
             throws Exception;
 
-    public Collection<String> asStrings(String paramName)
+    Collection<String> asStrings(String paramName)
             throws Exception;
 
-    public Number asNumber(String paramName, Mode mode)
+    Number asNumber(String paramName, Mode mode)
             throws Exception;
 
-    public Collection<Number> asNumbers(String paramName, Mode mode)
+    Collection<Number> asNumbers(String paramName, Mode mode)
             throws Exception;
 
-    public Number asNumber(String paramName)
+    Number asNumber(String paramName)
             throws Exception;
 
-    public Collection<Number> asNumbers(String paramName)
+    Collection<Number> asNumbers(String paramName)
             throws Exception;
 
-    public Date asDate(String paramName, Mode mode)
+    Date asDate(String paramName, Mode mode)
             throws Exception;
 
-    public Collection<Date> asDates(String paramName, Mode mode)
+    Collection<Date> asDates(String paramName, Mode mode)
             throws Exception;
 
-    public Date asDate(String paramName)
+    Date asDate(String paramName)
             throws Exception;
 
-    public Collection<Date> asDates(String paramName)
+    Collection<Date> asDates(String paramName)
             throws Exception;
 
-    public String toJSONString()
+    String toJSONString()
             throws Exception;
 
-    public String toJSONString(JSONStyle style)
+    String toJSONString(JSONStyle style)
             throws Exception;
 
-    public Map<String, Object> toMap()
+    Map<String, Object> toMap()
             throws Exception;
 
-    public JSONObject toJSONObject()
+    JSONObject toJSONObject()
             throws Exception;
 }

--- a/src/main/java/danta/api/configuration/ConfigurationProvider.java
+++ b/src/main/java/danta/api/configuration/ConfigurationProvider.java
@@ -28,10 +28,10 @@ package danta.api.configuration;
  */
 public interface ConfigurationProvider<T> {
 
-    public Configuration getFor(T id)
+    Configuration getFor(T id)
             throws Exception;
 
-    public boolean hasConfig(T id)
+    boolean hasConfig(T id)
             throws Exception;
 
 }


### PR DESCRIPTION
In order to simplify common operations (priority ordering) for DantaFramework/Core#12.

Blocks DantaFramework/Core#12